### PR TITLE
support PERLBREW_ROOT environment variable

### DIFF
--- a/lib/Ubic/Admin/Setup.pm
+++ b/lib/Ubic/Admin/Setup.pm
@@ -24,6 +24,7 @@ use Carp;
 use IPC::Open3;
 use File::Path;
 use File::Which;
+use File::Spec;
 
 use Ubic::AtomicFile;
 use Ubic::Settings;
@@ -335,7 +336,7 @@ sub setup {
             unless ($HOME) {
                 die "HOME env variable not defined";
             }
-            my $perlbrew_config = "$HOME/perl5/perlbrew/etc/bashrc";
+            my $perlbrew_config = File::Spec->catfile($ENV{PERLBREW_ROOT} || "$HOME/perl5/perlbrew", "etc/bashrc");
             if (not -e $perlbrew_config) {
                 die "Can't find perlbrew config (assumed $perlbrew_config)";
             }


### PR DESCRIPTION
Hi, we have several users that share a perlbrew installation, so it may live at /opt/perlbrew for instance and we indicate this to perlbrew with PERLBREW_ROOT. This change fixes an error I've run into installing Ubic:

t/setup.t ...................... Can't find perlbrew config (assumed /root/perl5/perlbrew/etc/bashrc) at /home/a1155544/local/src/Ubic/.build/JO9Ady32pG/lib/Ubic/Admin/Setup.pm line 295.

Cheers
