### PR TITLE
Fix Ubuntu crontab does not have /usr/local/bin in PATH

### DIFF
--- a/lib/Ubic/Admin/Setup.pm
+++ b/lib/Ubic/Admin/Setup.pm
@@ -351,6 +351,11 @@ sub setup {
             # TODO - what if PATH contains " quotes? hopefully nobody is that crazy...
             $crontab_env_fix .= qq[PATH="$ENV{PATH}" ];
         }
+        else {
+            require File::Basename;
+            my $path = File::Basename::dirname($ubic_watchdog_full_name);
+            $crontab_env_fix .= qq[PATH="$path\:\$PATH" ];
+        }
 
         if ($ENV{PERL5LIB}) {
             print_tty "\nYou're using custom PERL5LIB.\n";
@@ -443,7 +448,7 @@ sub setup {
         if ($crontab_wrap_bash) {
             $crontab_command = "bash -c '$crontab_command'";
         }
-        push @crontab_lines, "* * * * * $crontab_command    >>$log_dir/watchdog.log 2>>$log_dir/watchdog.err.log";
+        push @crontab_lines, "* * * * * $crontab_command >>$log_dir/watchdog.log 2>>$log_dir/watchdog.err.log";
         $printc->("$_\n") for @crontab_lines;
         close $fh or die "Can't close pipe: $!";
     }

--- a/t/bin/crontab
+++ b/t/bin/crontab
@@ -1,0 +1,14 @@
+#!/usr/bin/env perl
+
+open my $LOG, '>>', 'tfiles/crontab.log';
+
+print { $LOG } join ' ', @ARGV;
+print { $LOG } "\n";
+
+unless(-t STDIN) {
+    while(<STDIN>) {
+      print { $LOG } $_;
+    }
+}
+
+print { $LOG } "---\n";

--- a/t/setup-crontab.t
+++ b/t/setup-crontab.t
@@ -1,0 +1,43 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+use t::Utils;
+
+rebuild_tfiles();
+
+plan skip_all => 'Cannot run t/bin/crontab' if system 't/bin/crontab test';
+plan tests => 6;
+
+use Config;
+my $perl = $Config{perlpath};
+my @crontab_args;
+
+$ENV{ORIGINAL_HOME} = $ENV{HOME};
+$ENV{HOME} = 'tfiles';
+
+# removing perlbrew from path, to test default PATH prefix
+$ENV{PATH} = join ":", "bin", "t/bin", grep { ! /perlbrew/ } split /:/, $ENV{PATH};
+
+xsystem("$perl ./bin/ubic-admin setup --batch-mode --no-install-services --crontab --local --reconfigure");
+
+ok -e 'tfiles/crontab.log', 'called t/bin/crontab';
+
+open my $LOG, '<', 'tfiles/crontab.log' or die $!;
+
+while(<$LOG>) {
+  chomp $_;
+  push @crontab_args, $_;
+}
+
+is_deeply([ @crontab_args[2, 3] ], ['-l', '---'], 'crontab -l');
+is_deeply([ @crontab_args[4, 6] ], ['-', '---'], 'crontab -');
+
+like $crontab_args[5], qr{\* \* \* \* \*}, 'crontab entry will run every minute';
+like $crontab_args[5], qr{PATH="bin:\$PATH"}, 'crontab entry prefixed with PATH to ubic-watchdog';
+
+like(
+  $crontab_args[5],
+  qr{bin/ubic-watchdog ubic\.watchdog >>tfiles/ubic/log/watchdog\.log 2>>tfiles/ubic/log/watchdog\.err\.log},
+  'bin/ubic-watchdog ubic.watchdog with logging'
+);


### PR DESCRIPTION
I couldn't understand why my services didn't start on boot, but of course it had to do with crontab don't doing the right thing.

Maybe we could also make ubic log a bit more, when it fail to execute because of missing PATH entry, but I'm not sure where to do that.

I don't get why it's failing though, since I thought these lines in ubic and ubic-watchdog was supposed to fix that:

    unless (grep { $_ eq '/usr/local/bin' } split /:/, $ENV{PATH}) {
        $ENV{PATH} .= "/usr/local/bin:$ENV{PATH}";
    }

I would very much like the lines above to be removed, since it's messing things up when you have a custom perl installed in that location. I think having the right environment in the crontab is a better fix.