### PR TITLE
Added an additional check to pid_exists() in Daemon/OS/Linux.pm

### DIFF
--- a/lib/Ubic/Daemon/OS/Linux.pm
+++ b/lib/Ubic/Daemon/OS/Linux.pm
@@ -21,14 +21,14 @@ use parent qw(Ubic::Daemon::OS);
 sub pid2guid {
     my ($self, $pid) = @_;
 
-    unless (-d "/proc/$pid") {
+    unless ($self->pid_exists($pid)) {
         return; # process not found
     }
     my $opened = open(my $fh, '<', "/proc/$pid/stat");
     unless ($opened) {
         # open failed
         my $error = $!;
-        unless (-d "/proc/$pid") {
+        unless ($self->pid_exists($pid)) {
             return; # process exited right now
         }
         die "Open /proc/$pid/stat failed: $!";
@@ -78,7 +78,7 @@ sub close_all_fh {
 
 sub pid_exists {
     my ($self, $pid) = @_;
-    return (-d "/proc/$pid");
+    return (-d "/proc/$pid" && -e "/proc/$pid/exe");
 }
 
 1;


### PR DESCRIPTION
If a daemon dies (or exits), it can leave an unwaited for zombie
which pid_exists() still believes is running (because it just checks for the existence of the
/proc/$pid directory), the result is that ubic-guardian keeps looping around in the can_read loop and never restarts the dead process.

This change adds an additional check that /proc/$pid/exe exists (it doesn't for a zombie process)