### PR TITLE
hotfix_ping_status_for_ipv6only

### DIFF
--- a/lib/Ubic/UA.pm
+++ b/lib/Ubic/UA.pm
@@ -57,7 +57,8 @@ sub get {
     my $socket = IO::Socket::INET->new(
         PeerAddr => $authority,
         Proto    => 'tcp',
-        Timeout  => $self->{timeout}
+        Timeout  => $self->{timeout},
+        GetAddrInfoFlags => 0
     ) or return {error => $@};
     $socket->autoflush(1);
     $path .= '?' . $query if $query;


### PR DESCRIPTION
fix "Address family for hostname not supported" ping status for IPv6 only hosts