### PR TITLE
Fix "No pid X but waitpid didn't collect X status at Ubic/Daemon.pm" error

### DIFF
--- a/lib/Ubic/Daemon/OS/Linux.pm
+++ b/lib/Ubic/Daemon/OS/Linux.pm
@@ -90,7 +90,7 @@ sub pid_exists {
 
         last if $i >= 7;
 
-        warn "Failed to check PID '$pid' in '/proc', attempt $i. Sleeping '$check_interval' before next check."
+        warn "Failed to check PID '$pid' in '/proc', attempt $i. Sleeping '$check_interval' before next check.";
         sleep $check_interval;
         $check_interval = $check_interval*2;
     }

--- a/lib/Ubic/Daemon/OS/Linux.pm
+++ b/lib/Ubic/Daemon/OS/Linux.pm
@@ -78,7 +78,16 @@ sub close_all_fh {
 
 sub pid_exists {
     my ($self, $pid) = @_;
-    return (-d "/proc/$pid" && -e "/proc/$pid/exe");
+
+    for (my $i = 0; $i < 100; $i++) {
+        if (-d "/proc/$pid" && -e "/proc/$pid/exe") {
+            return 1;
+        }
+
+        sleep 0.001;
+    }
+
+    return;
 }
 
 1;

--- a/lib/Ubic/Daemon/OS/Linux.pm
+++ b/lib/Ubic/Daemon/OS/Linux.pm
@@ -78,13 +78,21 @@ sub close_all_fh {
 
 sub pid_exists {
     my ($self, $pid) = @_;
+    my $check_interval = 0.001;
 
-    for (my $i = 0; $i < 100; $i++) {
+    # Wait at most 127ms before giving up and returning false.
+    # This helps to avoid race: check can return false negative
+    # for its own process immediately after 'fork' in some cases.
+    for (my $i = 0; 1; $i++) {
         if (-d "/proc/$pid" && -e "/proc/$pid/exe") {
             return 1;
         }
 
-        sleep 0.001;
+        last if $i >= 7;
+
+        warn "Failed to check PID '$pid' in '/proc', attempt $i. Sleeping '$check_interval' before next check."
+        sleep $check_interval;
+        $check_interval = $check_interval*2;
     }
 
     return;


### PR DESCRIPTION
On Linux Ubic checks process existence using `/proc/` VFS and sometimes it faces a race in pid2guid conversion immediately after fork.

This leads to errors like
```
No pid X but waitpid didn't collect X status at Ubic/Daemon.pm" error
```
when starting a daemon. 
The daemon process actually starts but Ubic looses its track and shows it as 'not running'.

This patch makes Ubic to check for pid existence several times before giving up and reporting an error on Linux.