### PR TITLE
Set limit before change user. Fix formatting.

### DIFF
--- a/lib/Ubic/Service/SimpleDaemon.pm
+++ b/lib/Ubic/Service/SimpleDaemon.pm
@@ -257,13 +257,7 @@ sub start_impl {
         $start_params->{proxy_logs} = 1;
     }
     if ($self->{kill_child_signal}) {
-	    $start_params->{kill_child_signal} = $self->{kill_child_signal};
-	}	
-    if (defined $self->{daemon_user}) {
-        $start_params->{credentials} = Ubic::Credentials->new(
-            user => $self->{daemon_user},
-            group => $self->{daemon_group},
-        );
+        $start_params->{kill_child_signal} = $self->{kill_child_signal};
     }
     if (defined $self->{ulimit}) {
         $start_params->{start_hook} = sub {
@@ -275,6 +269,12 @@ sub start_impl {
                 }
             }
         };
+    }
+    if (defined $self->{daemon_user}) {
+        $start_params->{credentials} = Ubic::Credentials->new(
+            user => $self->{daemon_user},
+            group => $self->{daemon_group},
+        );
     }
     start_daemon($start_params);
 }


### PR DESCRIPTION
Without that fix when daemon start as unprivileged user ubic can't set new limit. Error at syscall like:
```
setrlimit(RLIMIT_NOFILE, {rlim_cur=64535, rlim_max=64535}) = -1 EPERM (Operation not permitted)
```